### PR TITLE
Signomial.chop to obtain Monomials. 

### DIFF
--- a/gpkit/nomials/math.py
+++ b/gpkit/nomials/math.py
@@ -262,6 +262,12 @@ class Signomial(Nomial):
     def __rsub__(self, other):
         return other + -self if SignomialsEnabled else NotImplemented  # pylint: disable=using-constant-test
 
+    def chop(self):
+        "Returns a list of monomials in the signomial."
+        monmaps = [NomialMap({exp: c}) for exp, c in self.hmap.items()]
+        for monmap in monmaps:
+            monmap.units = self.hmap.units
+        return [Monomial(monmap) for monmap in monmaps]
 
 class Posynomial(Signomial):
     "A Signomial with strictly positive cs"

--- a/gpkit/tests/t_nomials.py
+++ b/gpkit/tests/t_nomials.py
@@ -233,6 +233,17 @@ class TestSignomial(unittest.TestCase):
             self.assertEqual((1 - x/y**2).latex(), "-\\frac{x}{y^{2}} + 1")
         self.assertRaises(TypeError, lambda: x-y)
 
+    def test_chop(self):
+        x = Variable('x')
+        y = Variable('y')
+        with SignomialsEnabled():
+            c = x + 5.*y**2 - 0.2*x*y**0.78
+            monomials = c.chop()
+        with self.assertRaises(InvalidPosynomial):
+            c.chop()
+        with SignomialsEnabled():
+            self.assertIn(-0.2*x*y**0.78, monomials)
+
     def test_mult(self):
         "Test Signomial multiplication"
         x = Variable("x")


### PR DESCRIPTION
This is a standard way to chop posynomials and signomials (with SignomialsEnabled()) into their Monomials. Imagine this is super useful for a number of codebases (eg. robust). 