### PR TITLE
Appropriate verbosity check for 'SP not converging' warning. 

### DIFF
--- a/gpkit/constraints/sgp.py
+++ b/gpkit/constraints/sgp.py
@@ -155,7 +155,7 @@ class SequentialGeometricProgram(CostedConstraintSet):
                 cost = None  # reset the cost-counting
             if prevcost is None or cost is None:
                 rel_improvement = None
-            elif prevcost < (1-reltol)*cost:
+            elif prevcost < (1-reltol)*cost and verbosity>0:
                 print("SP is not converging! Last GP iteration had a higher"
                       " cost (%.2g) than the previous one (%.2g). Results for"
                       " each iteration are in (Model).program.results. If your"

--- a/gpkit/constraints/sgp.py
+++ b/gpkit/constraints/sgp.py
@@ -155,7 +155,7 @@ class SequentialGeometricProgram(CostedConstraintSet):
                 cost = None  # reset the cost-counting
             if prevcost is None or cost is None:
                 rel_improvement = None
-            elif prevcost < (1-reltol)*cost and verbosity>0:
+            elif prevcost < (1-reltol)*cost and verbosity > 0:
                 print("SP is not converging! Last GP iteration had a higher"
                       " cost (%.2g) than the previous one (%.2g). Results for"
                       " each iteration are in (Model).program.results. If your"


### PR DESCRIPTION
Pretty straightforward really. This warning really shouldn't pop up if verbosity=0.