### PR TITLE
support for mosek 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ htmlcov/
 nosetests.xml
 coverage.xml
 gplibrary/*
+gpkit/tests/*.csv
+gpkit/tests/*.txt
+gpkit/tests/*.mat
+gpkit/tests/*.pkl
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ __pycache__/
 .Python
 env/
 bin/
+gpkit/env/*
 build/
 develop-eggs/
 dist/
@@ -30,6 +31,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+gpkit/_mosek/build/*
 
 # Installer logs
 pip-log.txt
@@ -42,6 +44,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+gplibrary/*
 
 # Translations
 *.mo
@@ -76,3 +79,6 @@ test_reports_nounits/
 
 # OSX
 .DS_Store
+
+# Development environment
+.idea/

--- a/docs/source/examples/autosweep.py
+++ b/docs/source/examples/autosweep.py
@@ -36,7 +36,8 @@ bst1_loaded = pickle.load(open("autosweep.pkl", "rb"))
 # this problem is two intersecting lines in logspace
 m2 = Model(A**2, [A >= (l/3)**2, A >= (l/3)**0.5 * units.m**1.5])
 tol2 = {"mosek": 1e-12, "cvxopt": 1e-7,
-        "mosek_cli": 1e-6, 'mosek_conif': 1e-6}[gpkit.settings["default_solver"]]
+        "mosek_cli": 1e-6,
+        'mosek_conif': 1e-6}[gpkit.settings["default_solver"]]
 # test Model method
 sol2 = m2.autosweep({l: [1, 10]}, tol2, verbosity=0)
 bst2 = sol2.bst

--- a/docs/source/examples/autosweep.py
+++ b/docs/source/examples/autosweep.py
@@ -36,7 +36,7 @@ bst1_loaded = pickle.load(open("autosweep.pkl", "rb"))
 # this problem is two intersecting lines in logspace
 m2 = Model(A**2, [A >= (l/3)**2, A >= (l/3)**0.5 * units.m**1.5])
 tol2 = {"mosek": 1e-12, "cvxopt": 1e-7,
-        "mosek_cli": 1e-6}[gpkit.settings["default_solver"]]
+        "mosek_cli": 1e-6, 'mosek_conif': 1e-6}[gpkit.settings["default_solver"]]
 # test Model method
 sol2 = m2.autosweep({l: [1, 10]}, tol2, verbosity=0)
 bst2 = sol2.bst

--- a/gpkit/_cvxopt.py
+++ b/gpkit/_cvxopt.py
@@ -12,7 +12,7 @@ def cvxoptimize(c, A, k, *args, **kwargs):
         "[a,b] array of floats" indicates array-like data with shape [a,b]
         n is the number of monomials in the gp
         m is the number of variables in the gp
-        p is the number of posynomials in the gp
+        p is the number of posynomial constraints in the gp
 
         Arguments
         ---------
@@ -21,7 +21,8 @@ def cvxoptimize(c, A, k, *args, **kwargs):
         A : floats array of shape (n, m)
             Exponents of the various free variables for each monomial.
         k : ints array of shape p+1
-            number of monomials (columns of F) present in each constraint
+            k[0] is the number of monomials (rows of A) present in the objective
+            k[1:] is number of monomials (rows of A) present in each constraint
 
         Returns
         -------

--- a/gpkit/_cvxopt.py
+++ b/gpkit/_cvxopt.py
@@ -18,9 +18,9 @@ def cvxoptimize(c, A, k, *args, **kwargs):
         ---------
         c : floats array of shape n
             Coefficients of each monomial
-        A : floats array of shape (m,n)
+        A : floats array of shape (n, m)
             Exponents of the various free variables for each monomial.
-        k : ints array of shape n
+        k : ints array of shape p+1
             number of monomials (columns of F) present in each constraint
 
         Returns

--- a/gpkit/_cvxopt.py
+++ b/gpkit/_cvxopt.py
@@ -22,7 +22,7 @@ def cvxoptimize(c, A, k, *args, **kwargs):
             Exponents of the various free variables for each monomial.
         k : ints array of shape p+1
             k[0] is the number of monomials (rows of A) present in the objective
-            k[1:] is number of monomials (rows of A) present in each constraint
+            k[1:] is the number of monomials (rows of A) present in each constraint
 
         Returns
         -------

--- a/gpkit/_mosek/mosek_conif.py
+++ b/gpkit/_mosek/mosek_conif.py
@@ -22,10 +22,9 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
         k[0] is the number of monomials (rows of A) present in the objective
         k[1:] is the number of monomials (rows of A) present in each constraint
     p_idxs : list of bool arrays, each of shape m
-        p_idxs[i] selects rows of A and entries of c of the i-th posynomial
-        fi(x) = c[p_idxs[i]] @ exp(A[p_idxs[i],:] @ x). The 0-th posynomial
-        gives the objective function, and the remaining posynomials should
-        be constrained to be <= 1.
+        sel = p_idxs == i selects rows of A and entries of c of the i-th posynomial
+        fi(x) = c[sel] @ exp(A[sel,:] @ x). The 0-th posynomial gives the objective
+        function, and the remaining posynomials should be constrained to be <= 1.
 
     Returns
     -------
@@ -43,39 +42,48 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
     #
     #   Prepare some initial problem data
     #
-    #       Say that the optimization variable is y = [x;t], where
-    #       x is of length m, and t is of length 3*n. Entry
-    #       t[3*ell] is the epigraph variable for the ell-th monomial
-    #       t[3*ell + 1] should be == 1.
-    #       t[3*ell + 2] should be == A[ell, :] @ x.
+    #       Say that the optimization variable is y = [x;t;z], where
+    #       x is of length m, t is of length 3*n, and z is of length p+1.
+    #
+    #       Triples
+    #           t[3*ell]
+    #           t[3*ell + 1] should be == 1.
+    #           t[3*ell + 2] should be == A[ell, :] @ x + np.log(c[ell]) - z[posynom idx corresponding to ell].
+    #       should belong to the exponential cone.
+    #
+    #       For each i from {0,...,p}, the "t" should also satisfy
+    #           sum(t[3*ell] for ell correponsing to posynomial i) <= 1.
+    #
+    #       The vector "z" should satisfy
+    #           z[1:] <= 0
+    #
     #
     c = np.array(c)
     n, m = A.shape
     p = len(k) - 1
-    n_msk = m + 3*n
+    n_msk = m + 3*n + p + 1
     #
     #   Create MOSEK task. add variables and conic constraints.
     #
     env = mosek.Env()
     task = env.Task(0, 0)
     task.appendvars(n_msk)
+    bound_types = [mosek.boundkey.fr] * (m + 3*n + 1) + [mosek.boundkey.up] * p
     task.putvarboundlist(np.arange(n_msk, dtype=int),
-                         [mosek.boundkey.fr] * n_msk,
-                         np.zeros(n_msk),
-                         np.zeros(n_msk))
+                         bound_types, np.zeros(n_msk), np.zeros(n_msk))
     for i in range(n):
         idx = m + 3*i
         task.appendcone(mosek.conetype.pexp, 0.0, np.arange(idx, idx + 3))
     #
     #   Calls to MOSEK's "putaijlist"
     #
-    task.appendcons(2*n + p)
+    task.appendcons(2*n + p + 1)
     # Linear equations: t[3*ell + 1] == 1.
     rows = [i for i in range(n)]
     cols = (m + 3*np.arange(n) + 1).tolist()
     vals = [1.0] * n
     task.putaijlist(rows, cols, vals)
-    # Linear equations: A[ell,:] @ x  - t[3*ell + 2] == -np.log(c[ell])
+    # Linear equations: A[ell,:] @ x  - t[3*ell + 2] - z[posynom idx corresponding to ell] == -np.log(c[ell])
     cur_con_idx = n
     rows = [cur_con_idx + r for r in A.row]
     task.putaijlist(rows, A.col, A.data)
@@ -83,11 +91,15 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
     cols = (m + 3*np.arange(n) + 2).tolist()
     vals = [-1.0] * n
     task.putaijlist(rows, cols, vals)
-    # Linear inequalities: 1 @ t[3 * sels] <= 1, for sels = np.nonzero(p_idxs[i])
+    rows = [cur_con_idx + i for i in range(n)]
+    cols = [m + 3*n + p_idxs[i] for i in range(n)]
+    vals = [-1.0] * n
+    task.putaijlist(rows, cols, vals)
+    # Linear inequalities: 1 @ t[3 * sels] <= 1, for sels = np.nonzero(p_idxs[i] == i)
     cur_con_idx = 2*n
     rows, cols, vals = [], [], []
-    for i in range(p):
-        sels = np.nonzero(p_idxs == (i + 1))[0]
+    for i in range(p+1):
+        sels = np.nonzero(p_idxs == i)[0]
         rows.extend([cur_con_idx] * sels.size)
         cols.extend(m + 3 * sels)
         vals.extend([1] * sels.size)
@@ -96,15 +108,13 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
     #
     #   Build the right-hand-sides of the [in]equality constraints
     #
-    type_constraint = [mosek.boundkey.fx] * (2*n) + [mosek.boundkey.up] * p
-    h = np.concatenate([np.ones(n), -np.log(c), np.ones(p)])
+    type_constraint = [mosek.boundkey.fx] * (2*n) + [mosek.boundkey.up] * (p + 1)
+    h = np.concatenate([np.ones(n), -np.log(c), np.ones(p + 1)])
     task.putconboundlist(np.arange(h.size, dtype=int), type_constraint, h, h)
     #
     #   Set the objective function
     #
-    sels = np.nonzero(p_idxs == 0)[0]
-    cols = (m + 3 * sels).tolist()
-    task.putclist(cols, [1] * sels.size)
+    task.putclist([int(m + 3*n)], [1])
     task.putobjsense(mosek.objsense.minimize)
     #
     #   Set solver parameters, and call .solve().
@@ -116,14 +126,18 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
     msk_solsta = task.getsolsta(mosek.soltype.itr)
     if msk_solsta == mosek.solsta.optimal:
         str_status = 'optimal'
+        # recover primal variables
         x = [0.] * m
         task.getxxslice(mosek.soltype.itr, 0, m, x)
-        z = [0.] * p
-        task.getsucslice(mosek.soltype.itr, 2*n, 2*n + p, z)
-        z = np.array(z)
-        z[z < 0] = 0
         x = np.array(x)
-        solution = {'status': str_status, 'primal': x, 'la': z}
+        # recover dual variables for log-sum-exp epigraph constraints
+        # (skip epigraph of the objective function).
+        z_duals = [0.] * p
+        task.getsuxslice(mosek.soltype.itr, m + 3*n + 1, n_msk, z_duals)
+        z_duals = np.array(z_duals)
+        z_duals[z_duals < 0] = 0
+        # wrap things up in a dictionary
+        solution = {'status': str_status, 'primal': x, 'la': z_duals}
     elif msk_solsta == mosek.solsta.prim_infeas_cer:
         str_status = 'infeasible'
         solution = {'status': str_status, 'primal': None}

--- a/gpkit/_mosek/mosek_conif.py
+++ b/gpkit/_mosek/mosek_conif.py
@@ -21,7 +21,7 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
     k : ints array of shape p+1
         k[0] is the number of monomials (rows of A) present in the objective
         k[1:] is the number of monomials (rows of A) present in each constraint
-    p_idxs : list of bool arrays, each of shape m
+    p_idxs : ints array of shape n.
         sel = p_idxs == i selects rows of A and entries of c of the i-th posynomial
         fi(x) = c[sel] @ exp(A[sel,:] @ x). The 0-th posynomial gives the objective
         function, and the remaining posynomials should be constrained to be <= 1.
@@ -30,133 +30,144 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
     -------
     dict
         Contains the following keys
-            "success": bool
-            "objective_sol" float
-                Optimal value of the objective
-            "primal_sol": floats array of size m
-                Optimal value of free variables. Note: not in logspace.
-            "dual_sol": floats array of size p
-                Optimal value of the dual variables, in logspace.
+            "status": string
+                "optimal", "infeasible", "unbounded", or "unknown".
+            "primal" np.ndarray or None
+                The values of the ``m`` primal variables.
+            "la": np.ndarray or None
+                The dual variables to the ``p`` posynomial constraints, when
+                those constraints are represented in log-sum-exp ("LSE") form.
     """
     import mosek
     #
-    #   Prepare some initial problem data
+    #   Initial transformations of problem data.
     #
-    #       Say that the optimization variable is y = [x;t;z], where
-    #       x is of length m, t is of length 3*n, and z is of length p+1.
+    #       separate monomial constraints (call them "lin"), from those which require
+    #       an LSE representation (call those "lse").
     #
-    #       Triples
-    #           t[3*ell]
-    #           t[3*ell + 1] should be == 1.
-    #           t[3*ell + 2] should be == A[ell, :] @ x + np.log(c[ell]) - z[posynom idx corresponding to ell].
-    #       should belong to the exponential cone.
+    #       NOTE: the epigraph of the objective function always gets an "lse"
+    #       representation, even if the objective is a monomial.
     #
-    #       For each i from {0,...,p}, the "t" should also satisfy
-    #           sum(t[3*ell] for ell correponsing to posynomial i) <= 1.
-    #
-    #       The vector "z" should satisfy
-    #           z[1:] <= 0
-    #
-    #
-    c = np.array(c)
-    # separate exponential from linear constraints.
-    # the objective is always kept in exponential form.
-    exp_posys = [0] + [i+1 for i, val in enumerate(k[1:]) if val > 1]
-    lin_posys = [i for i in range(len(k)) if i not in exp_posys]
+    log_c = np.log(np.array(c))
+    lse_posys = [0] + [i+1 for i, val in enumerate(k[1:]) if val > 1]
+    lin_posys = [i for i in range(len(k)) if i not in lse_posys]
     if len(lin_posys) > 0:
         A = A.tocsr()
-        lin_idxs = []
-        for i in lin_posys:
-            temp = np.nonzero(p_idxs == i)
-            temp = temp[0]
-            lin_idxs.append(temp)
-        lin_idxs = np.concatenate(lin_idxs)
-        nonlin_idxs = np.ones(A.shape[0], dtype=bool)
-        nonlin_idxs[lin_idxs] = False
-        A_exp = A[nonlin_idxs, :].tocoo()
-        c_exp = c[nonlin_idxs]
+        lin_idxs = np.concatenate([np.nonzero(p_idxs == i)[0] for i in lin_posys])
+        lse_idxs = np.ones(A.shape[0], dtype=bool)
+        lse_idxs[lin_idxs] = False
+        A_lse = A[lse_idxs, :].tocoo()
+        log_c_lse = log_c[lse_idxs]
         A_lin = A[lin_idxs, :].tocoo()
-        c_lin = c[lin_idxs]
+        log_c_lin = log_c[lin_idxs]
     else:
-        c_lin = np.array([])
-        A_exp = A
-        c_exp = c
-
-    m = A.shape[1]
-    k_exp = [k[i] for i in exp_posys]
-    n_exp = sum(k_exp)
-    p_exp = len(k_exp)
-    n_msk = m + 3*n_exp + p_exp
-    exp_p_idx = []
-    for i, ki in enumerate(k_exp):
-        exp_p_idx.extend([i] * ki)
-    exp_p_idx = np.array(exp_p_idx)
+        log_c_lin = np.array([])  # A_lin won't be referenced later, so no need to define it.
+        A_lse = A
+        log_c_lse = log_c
+    k_lse = [k[i] for i in lse_posys]
+    n_lse = sum(k_lse)
+    p_lse = len(k_lse)
+    lse_p_idx = []
+    for i, ki in enumerate(k_lse):
+        lse_p_idx.extend([i] * ki)
+    lse_p_idx = np.array(lse_p_idx)
     #
-    #   Create MOSEK task. add variables and conic constraints.
+    #   Create MOSEK task. Add variables, and conic constraints.
+    #
+    #       Say that MOSEK's optimization variable is a block vector, [x;t;z], where ...
+    #           x is the user-defined primal variable (length m),
+    #           t is an auxiliary variable for exponential cones (length 3 * n_lse), and
+    #           z is an epigraph variable for LSE terms (length p_lse).
+    #
+    #       The variable z[0] is special, because it's the epigraph of the objective function
+    #       in LSE form. The sign of this variable is not constrained.
+    #
+    #       The variables z[1:] are epigraph terms for "log", in constraints that naturally
+    #       write as LSE(Ai @ x + log_ci) <= 0. These variables need to be <= 0.
+    #
+    #       The main constraints on (x, t, z) are described in next comment block.
     #
     env = mosek.Env()
     task = env.Task(0, 0)
-    task.appendvars(n_msk)
-    bound_types = [mosek.boundkey.fr] * (m + 3*n_exp + 1) + [mosek.boundkey.up] * (p_exp - 1)
-    task.putvarboundlist(np.arange(n_msk, dtype=int),
-                         bound_types, np.zeros(n_msk), np.zeros(n_msk))
-    for i in range(n_exp):
+    m = A.shape[1]
+    msk_nvars = m + 3 * n_lse + p_lse
+    task.appendvars(msk_nvars)
+    bound_types = [mosek.boundkey.fr] * (m + 3*n_lse + 1) + [mosek.boundkey.up] * (p_lse - 1)
+    task.putvarboundlist(np.arange(msk_nvars, dtype=int),
+                         bound_types, np.zeros(msk_nvars), np.zeros(msk_nvars))
+    for i in range(n_lse):
         idx = m + 3*i
         task.appendcone(mosek.conetype.pexp, 0.0, np.arange(idx, idx + 3))
     #
     #   Affine constraints related to the exponential cone
     #
-    task.appendcons(2*n_exp + p_exp)
-    # 1st n_exp: Linear equations: t[3*ell + 1] == 1
-    rows = [i for i in range(n_exp)]
-    cols = (m + 3*np.arange(n_exp) + 1).tolist()
-    vals = [1.0] * n_exp
+    #       For each i in {0, ..., n_lse - 1}, we need
+    #           t[3*i + 1] == 1, and
+    #           t[3*i + 2] == A_lse[i, :] @ x + log_c_lse[i] - z[lse_p_idx[i]].
+    #       This contributes 2 * n_lse constraints.
+    #
+    #       For each j from {0, ..., p_lse - 1}, the "t" should also satisfy
+    #           sum(t[3*i] for i where i == lse_p_idx[j]) <= 1.
+    #       This contributes another p_lse constraints.
+    #
+    #       The above constraints imply that for ``sel = lse_p_idx == i``, we have
+    #           LSE(A_lse[sel, :] @ x + log_c_lse[sel]) <= z[i].
+    #
+    #       We specify the necessary constraints to MOSEK in three phases. Over the
+    #       course of these three phases, we make a total of five calls to "putaijlist"
+    #       and a single call to "putconboundlist".
+    #
+    task.appendcons(2*n_lse + p_lse)
+    # 1st n_lse: Linear equations: t[3*i + 1] == 1
+    rows = [i for i in range(n_lse)]
+    cols = (m + 3*np.arange(n_lse) + 1).tolist()
+    vals = [1.0] * n_lse
     task.putaijlist(rows, cols, vals)
-    # 2nd n_exp: Linear equations:
-    #       A[ell,:] @ x  - t[3*ell + 2] - z[posynom idx corresponding to ell] == -np.log(c[ell])
-    cur_con_idx = n_exp
-    rows = [cur_con_idx + r for r in A_exp.row]
-    task.putaijlist(rows, A_exp.col, A_exp.data)
-    rows = [cur_con_idx + i for i in range(n_exp)]
-    cols = (m + 3*np.arange(n_exp) + 2).tolist()
-    vals = [-1.0] * n_exp
-    task.putaijlist(rows, cols, vals)
-    rows = [cur_con_idx + i for i in range(n_exp)]
-    cols = [m + 3*n_exp + exp_p_idx[i] for i in range(n_exp)]
-    vals = [-1.0] * n_exp
-    task.putaijlist(rows, cols, vals)
-    # last p_exp: Linear inequalities:
-    #       1 @ t[3 * sels] <= 1, for sels = np.nonzero(exp_p_idxs[i] == i)
-    cur_con_idx = 2*n_exp
+    cur_con_idx = n_lse
+    # 2nd n_lse: Linear equations between (x,t,z).
+    rows = [cur_con_idx + r for r in A_lse.row]
+    task.putaijlist(rows, A_lse.col, A_lse.data)  # coefficients on "x"
+    rows = [cur_con_idx + i for i in range(n_lse)]
+    cols = (m + 3*np.arange(n_lse) + 2).tolist()
+    vals = [-1.0] * n_lse
+    task.putaijlist(rows, cols, vals)  # coefficients on "t"
+    rows = [cur_con_idx + i for i in range(n_lse)]
+    cols = [m + 3*n_lse + lse_p_idx[i] for i in range(n_lse)]
+    vals = [-1.0] * n_lse
+    task.putaijlist(rows, cols, vals)  # coefficients on "z".
+    cur_con_idx = 2 * n_lse
+    # last p_lse: Linear inequalities on certain sums of "t".
     rows, cols, vals = [], [], []
-    for i in range(p_exp):
-        sels = np.nonzero(exp_p_idx == i)[0]
+    for i in range(p_lse):
+        sels = np.nonzero(lse_p_idx == i)[0]
         rows.extend([cur_con_idx] * sels.size)
         cols.extend(m + 3 * sels)
         vals.extend([1] * sels.size)
         cur_con_idx += 1
     task.putaijlist(rows, cols, vals)
+    cur_con_idx = 2 * n_lse + p_lse
     # Build the right-hand-sides of the [in]equality constraints
-    type_constraint = [mosek.boundkey.fx] * (2*n_exp) + [mosek.boundkey.up] * p_exp
-    h = np.concatenate([np.ones(n_exp), -np.log(c_exp), np.ones(p_exp)])
+    type_constraint = [mosek.boundkey.fx] * (2*n_lse) + [mosek.boundkey.up] * p_lse
+    h = np.concatenate([np.ones(n_lse), -log_c_lse, np.ones(p_lse)])
     task.putconboundlist(np.arange(h.size, dtype=int), type_constraint, h, h)
     #
     #   Affine constraints, not needing the exponential cone
     #
-    cur_con_idx = 2*n_exp + p_exp
-    if c_lin.size > 0:
-        task.appendcons(c_lin.size)
+    #       Require A_lin @ x <= -log_c_lin.
+    #
+    if log_c_lin.size > 0:
+        task.appendcons(log_c_lin.size)
         rows = [cur_con_idx + r for r in A_lin.row]
         task.putaijlist(rows, A_lin.col, A_lin.data)
-        type_constraint = [mosek.boundkey.up] * c_lin.size
-        con_indices = np.arange(cur_con_idx, cur_con_idx + c_lin.size, dtype=int)
-        h = -np.log(c_lin)
+        type_constraint = [mosek.boundkey.up] * log_c_lin.size
+        con_indices = np.arange(cur_con_idx, cur_con_idx + log_c_lin.size, dtype=int)
+        h = -log_c_lin
         task.putconboundlist(con_indices, type_constraint, h, h)
-        cur_con_idx += c_lin.size
+        cur_con_idx += log_c_lin.size
     #
     #   Set the objective function
     #
-    task.putclist([int(m + 3*n_exp)], [1])
+    task.putclist([int(m + 3*n_lse)], [1])
     task.putobjsense(mosek.objsense.minimize)
     #
     #   Set solver parameters, and call .solve().
@@ -192,19 +203,19 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
         x = np.array(x)
         # recover dual variables for log-sum-exp epigraph constraints
         # (skip epigraph of the objective function).
-        z_duals = [0.] * (p_exp - 1)
-        task.getsuxslice(mosek.soltype.itr, m + 3*n_exp + 1, n_msk, z_duals)
+        z_duals = [0.] * (p_lse - 1)
+        task.getsuxslice(mosek.soltype.itr, m + 3*n_lse + 1, msk_nvars, z_duals)
         z_duals = np.array(z_duals)
         z_duals[z_duals < 0] = 0
         # recover dual variables for the remaining user-provided constraints
-        if c_lin.size > 0:
-            aff_duals = [0.] * c_lin.size
-            task.getsucslice(mosek.soltype.itr, 2*n_exp + p_exp, cur_con_idx, aff_duals)
+        if log_c_lin.size > 0:
+            aff_duals = [0.] * log_c_lin.size
+            task.getsucslice(mosek.soltype.itr, 2*n_lse + p_lse, cur_con_idx, aff_duals)
             aff_duals = np.array(aff_duals)
             aff_duals[aff_duals < 0] = 0
             # merge z_duals with aff_duals
             merged_duals = np.zeros(len(k))
-            merged_duals[exp_posys[1:]] = z_duals
+            merged_duals[lse_posys[1:]] = z_duals
             merged_duals[lin_posys] = aff_duals
             merged_duals = merged_duals[1:]
         else:
@@ -212,11 +223,11 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
         # wrap things up in a dictionary
         solution = {'status': 'optimal', 'primal': x, 'la': merged_duals}
     elif msk_solsta == mosek.solsta.prim_infeas_cer:
-        solution = {'status': 'infeasible', 'primal': None}
+        solution = {'status': 'infeasible', 'primal': None, 'la': None}
     elif msk_solsta == mosek.solsta.dual_infeas_cer:
-        solution = {'status': 'unbounded', 'primal': None}
+        solution = {'status': 'unbounded', 'primal': None, 'la': None}
     else:
-        solution = {'status': 'unknown', 'primal': None}
+        solution = {'status': 'unknown', 'primal': None, 'la': None}
     task.__exit__(None, None, None)
     env.__exit__(None, None, None)
     return solution

--- a/gpkit/_mosek/mosek_conif.py
+++ b/gpkit/_mosek/mosek_conif.py
@@ -1,0 +1,132 @@
+"Implements the GPkit interface to MOSEK (version >= 9) python-based Optimizer API"
+
+import numpy as np
+
+
+def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
+    """
+    Definitions
+    -----------
+    "[a,b] array of floats" indicates array-like data with shape [a,b]
+    n is the number of monomials in the gp
+    m is the number of variables in the gp
+    p is the number of posynomial constraints in the gp
+
+    Arguments
+    ---------
+    c : floats array of shape n
+        Coefficients of each monomial
+    A : gpkit.small_classes.CootMatrix, of shape (n, m)
+        Exponents of the various free variables for each monomial.
+    k : ints array of shape p+1
+        k[0] is the number of monomials (rows of A) present in the objective
+        k[1:] is the number of monomials (rows of A) present in each constraint
+    p_idxs : list of bool arrays, each of shape m
+        p_idxs[i] selects rows of A and entries of c of the i-th posynomial
+        fi(x) = c[p_idxs[i]] @ exp(A[p_idxs[i],:] @ x). The 0-th posynomial
+        gives the objective function, and the remaining posynomials should
+        be constrained to be <= 1.
+
+    Returns
+    -------
+    dict
+        Contains the following keys
+            "success": bool
+            "objective_sol" float
+                Optimal value of the objective
+            "primal_sol": floats array of size m
+                Optimal value of free variables. Note: not in logspace.
+            "dual_sol": floats array of size p
+                Optimal value of the dual variables, in logspace.
+    """
+    import mosek
+    #
+    #   Prepare some initial problem data
+    #
+    #       Say that the optimization variable is y = [x;t], where
+    #       x is of length m, and t is of length 3*n. Entry
+    #       t[3*ell] is the epigraph variable for the ell-th monomial
+    #       t[3*ell + 1] should be == 1.
+    #       t[3*ell + 2] should be == A[ell, :] @ x.
+    #
+    c = np.array(c)
+    n, m = A.shape
+    p = len(p_idxs) - 1
+    n_msk = m + 3*n
+    #
+    #   Create MOSEK task. add variables and conic constraints.
+    #
+    env = mosek.Env()
+    task = env.Task(0, 0)
+    task.appendvars(n_msk)
+    task.putvarboundlist(np.arange(n_msk, dtype=int),
+                         [mosek.boundkey.fr] * n_msk,
+                         np.zeros(n_msk),
+                         np.zeros(n_msk))
+    for i in range(n):
+        idx = m + 3*i
+        task.appendcone(mosek.conetype.pexp, 0.0, np.arange(idx, idx + 3))
+    #
+    #   Calls to MOSEK's "putaijlist"
+    #
+    task.appendcons(2*n + p)
+    # Linear equations: t[3*ell + 1] == 1.
+    rows = [i for i in range(n)]
+    cols = (m + 3*np.arange(n) + 1).tolist()
+    vals = [1.0] * n
+    task.putaijlist(rows, cols, vals)
+    # Linear equations: A[ell,:] @ x - t[3*ell + 2] == 0
+    cur_con_idx = n
+    rows = [cur_con_idx + r for r in A.rows]
+    task.putaijlist(rows, A.cols, A.vals)
+    rows = [cur_con_idx + i for i in range(n)]
+    cols = (m + 3*np.arange(n) + 2).tolist()
+    vals = [-1.0] * n
+    task.putaijlist(rows, cols, vals)
+    # Linear inequalities: c[sels] @ t[3 * sels] <= 1, for sels = np.nonzero(p_idxs[i])
+    cur_con_idx = 2*n
+    rows, cols, vals = [], [], []
+    for i in range(p):
+        sels = np.nonzero(p_idxs[i + 1])[0]
+        rows.extend([cur_con_idx] * sels.size)
+        cols.extend(m + 3 * sels)
+        vals.extend(c[sels])
+        cur_con_idx += 1
+    task.putaijlist(rows, cols, vals)
+    #
+    #   Build the right-hand-sides of the [in]equality constraints
+    #
+    type_constraint = [mosek.boundkey.fx] * (2*n) + [mosek.boundkey.up] * p
+    h = np.concatenate([np.ones(n), np.zeros(n), np.ones(p)])
+    task.putconboundlist(np.arange(h.size, dtype=int), type_constraint, h, h)
+    #
+    #   Set the objective function
+    #
+    sels = np.nonzero(p_idxs[0])[0]
+    cols = (m + 3 * sels).tolist()
+    task.putclist(cols, c[sels].tolist())
+    task.putobjsense(mosek.objsense.minimize)
+    #
+    #   Set solver parameters, and call .solve().
+    #
+    task.optimize()
+    #
+    #   Recover the solution
+    #
+    msk_solsta = task.getsolsta(mosek.soltype.itr)
+    if msk_solsta == mosek.solsta.optimal:
+        str_status = 'optimal'
+        x = [0.] * m
+        task.getxxslice(mosek.soltype.itr, 0, len(x), x)
+        solution = {'status': str_status, 'primal': np.array(x)}
+        return solution
+    elif msk_solsta == mosek.solsta.prim_infeas_cer:
+        str_status = 'infeasible'
+        solution = {'status': str_status, 'primal': None}
+        return solution
+    elif msk_solsta == mosek.solsta.dual_infeas_cer:
+        str_status = 'unbounded'
+        solution = {'status': str_status, 'primal': None}
+        return solution
+    else:
+        raise RuntimeError('Unexpected solver status.')

--- a/gpkit/_mosek/mosek_conif.py
+++ b/gpkit/_mosek/mosek_conif.py
@@ -39,6 +39,12 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
                 those constraints are represented in log-sum-exp ("LSE") form.
     """
     import mosek
+    if not hasattr(mosek.conetype, 'pexp'):
+        msg = """
+        mosek_conif requires MOSEK version >= 9. The imported version of MOSEK does
+        not have attribute ``mosek.conetype.pexp``, which was introduced in MOSEK 9. 
+        """
+        raise RuntimeError(msg)
     #
     #   Initial transformations of problem data.
     #

--- a/gpkit/_mosek/mosek_conif.py
+++ b/gpkit/_mosek/mosek_conif.py
@@ -125,7 +125,6 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
     #
     msk_solsta = task.getsolsta(mosek.soltype.itr)
     if msk_solsta == mosek.solsta.optimal:
-        str_status = 'optimal'
         # recover primal variables
         x = [0.] * m
         task.getxxslice(mosek.soltype.itr, 0, m, x)
@@ -137,15 +136,13 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
         z_duals = np.array(z_duals)
         z_duals[z_duals < 0] = 0
         # wrap things up in a dictionary
-        solution = {'status': str_status, 'primal': x, 'la': z_duals}
+        solution = {'status': 'optimal', 'primal': x, 'la': z_duals}
     elif msk_solsta == mosek.solsta.prim_infeas_cer:
-        str_status = 'infeasible'
-        solution = {'status': str_status, 'primal': None}
+        solution = {'status': 'infeasible', 'primal': None}
     elif msk_solsta == mosek.solsta.dual_infeas_cer:
-        str_status = 'unbounded'
-        solution = {'status': str_status, 'primal': None}
+        solution = {'status': 'unbounded', 'primal': None}
     else:
-        raise RuntimeError('Unexpected solver status.')
+        solution = {'status': 'unknown', 'primal': None}
     task.__exit__(None, None, None)
     env.__exit__(None, None, None)
     return solution

--- a/gpkit/_mosek/mosek_conif.py
+++ b/gpkit/_mosek/mosek_conif.py
@@ -83,7 +83,8 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
         lse_p_idx.extend([i] * ki)
     lse_p_idx = np.array(lse_p_idx)
     #
-    #   Create MOSEK task. Add variables, and conic constraints.
+    #   Create MOSEK task. Add variables, bound constraints, and conic
+    #   constraints.
     #
     #       Say that MOSEK's optimization variable is a block vector, [x;t;z],
     #       where ...
@@ -108,53 +109,51 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
     m = A.shape[1]
     msk_nvars = m + 3 * n_lse + p_lse
     task.appendvars(msk_nvars)
-    bound_types = [mosek.boundkey.fr] * (m + 3*n_lse + 1)
-    bound_types.extend([mosek.boundkey.up] * (p_lse - 1))
-    task.putvarboundlist(np.arange(msk_nvars, dtype=int),
-                         bound_types, np.zeros(msk_nvars), np.zeros(msk_nvars))
-    for i in range(n_lse):
-        idx = m + 3*i
-        task.appendcone(mosek.conetype.pexp, 0.0, np.arange(idx, idx + 3))
+    # "x" is free
+    task.putvarboundlist(np.arange(m), [mosek.boundkey.fr] * m,
+                         np.zeros(m), np.zeros(m))
+    # t[3 * i + i] == 1, other components are free.
+    bound_types = [mosek.boundkey.fr, mosek.boundkey.fx, mosek.boundkey.fr]
+    task.putvarboundlist(np.arange(m, m + 3*n_lse), bound_types * n_lse,
+                         np.ones(3*n_lse), np.ones(3*n_lse))
+    # z[0] is free; z[1:] <= 0.
+    bound_types = [mosek.boundkey.fr] + [mosek.boundkey.up] * (p_lse - 1)
+    task.putvarboundlist(np.arange(m + 3*n_lse, msk_nvars), bound_types,
+                         np.zeros(p_lse), np.zeros(p_lse))
+    # t[3*i], t[3*i + 1], t[3*i + 2] belongs to the exponential cone
+    task.appendconesseq([mosek.conetype.pexp] * n_lse, [0.0] * n_lse,
+                        [3] * n_lse, m)
     #
-    #   Affine constraints related to the exponential cone
+    #   Exponential cone affine constraints (other than t[3*i + 1] == 1).
     #
     #       For each i in {0, ..., n_lse - 1}, we need
-    #           t[3*i + 1] == 1, and
     #           t[3*i + 2] == A_lse[i, :] @ x + log_c_lse[i] - z[lse_p_idx[i]].
-    #       This contributes 2 * n_lse constraints.
     #
     #       For each j from {0, ..., p_lse - 1}, the "t" should also satisfy
     #           sum(t[3*i] for i where i == lse_p_idx[j]) <= 1.
-    #       This contributes another p_lse constraints.
     #
-    #       The above constraints imply that for ``sel = lse_p_idx == i``,
-    #       we have
-    #           LSE(A_lse[sel, :] @ x + log_c_lse[sel]) <= z[i].
+    #       When combined with bound constraints ``t[3*i + 1] == 1``, the
+    #       above constraints imply
+    #           LSE(A_lse[sel, :] @ x + log_c_lse[sel]) <= z[i]
+    #       for ``sel = lse_p_idx == i``.
     #
-    #       We specify the necessary constraints to MOSEK in three phases.
-    #       Over the course of these three phases, we make a total of five
-    #       calls to "putaijlist" and a single call to "putconboundlist".
-    #
-    task.appendcons(2*n_lse + p_lse)
-    # 1st n_lse: Linear equations: t[3*i + 1] == 1
-    rows = list(range(n_lse))
-    cols = (m + 3*np.arange(n_lse) + 1).tolist()
-    vals = [1.0] * n_lse
+    task.appendcons(n_lse + p_lse)
+    # Linear equations between (x,t,z).
+    #   start with coefficients on "x"
+    rows = [r for r in A_lse.row]
+    cols = [c for c in A_lse.col]
+    vals = [v for v in A_lse.data]
+    #   add coefficients on "t"
+    rows += list(range(n_lse))
+    cols += (m + 3*np.arange(n_lse) + 2).tolist()
+    vals += [-1.0] * n_lse
+    #   add coefficients on "z"
+    rows += list(range(n_lse))
+    cols += [m + 3*n_lse + lse_p_idx[i] for i in range(n_lse)]
+    vals += [-1.0] * n_lse
     task.putaijlist(rows, cols, vals)
     cur_con_idx = n_lse
-    # 2nd n_lse: Linear equations between (x,t,z).
-    rows = [cur_con_idx + r for r in A_lse.row]
-    task.putaijlist(rows, A_lse.col, A_lse.data)  # coefficients on "x"
-    rows = [cur_con_idx + i for i in range(n_lse)]
-    cols = (m + 3*np.arange(n_lse) + 2).tolist()
-    vals = [-1.0] * n_lse
-    task.putaijlist(rows, cols, vals)  # coefficients on "t"
-    rows = [cur_con_idx + i for i in range(n_lse)]
-    cols = [m + 3*n_lse + lse_p_idx[i] for i in range(n_lse)]
-    vals = [-1.0] * n_lse
-    task.putaijlist(rows, cols, vals)  # coefficients on "z".
-    cur_con_idx = 2 * n_lse
-    # last p_lse: Linear inequalities on certain sums of "t".
+    # Linear inequalities on certain sums of "t".
     rows, cols, vals = [], [], []
     for i in range(p_lse):
         sels = np.nonzero(lse_p_idx == i)[0]
@@ -163,11 +162,9 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
         vals.extend([1] * sels.size)
         cur_con_idx += 1
     task.putaijlist(rows, cols, vals)
-    cur_con_idx = 2 * n_lse + p_lse
     # Build the right-hand-sides of the [in]equality constraints
-    type_constraint = [mosek.boundkey.fx] * (2*n_lse)
-    type_constraint.extend([mosek.boundkey.up] * p_lse)
-    h = np.concatenate([np.ones(n_lse), -log_c_lse, np.ones(p_lse)])
+    type_constraint = [mosek.boundkey.fx] * n_lse + [mosek.boundkey.up] * p_lse
+    h = np.concatenate([-log_c_lse, np.ones(p_lse)])
     task.putconboundlist(np.arange(h.size, dtype=int), type_constraint, h, h)
     #
     #   Affine constraints, not needing the exponential cone
@@ -179,8 +176,7 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
         rows = [cur_con_idx + r for r in A_lin.row]
         task.putaijlist(rows, A_lin.col, A_lin.data)
         type_constraint = [mosek.boundkey.up] * log_c_lin.size
-        con_indices = np.arange(cur_con_idx, cur_con_idx + log_c_lin.size,
-                                dtype=int)
+        con_indices = np.arange(cur_con_idx, cur_con_idx + log_c_lin.size)
         h = -log_c_lin
         task.putconboundlist(con_indices, type_constraint, h, h)
         cur_con_idx += log_c_lin.size
@@ -230,7 +226,7 @@ def mskoptimize(c, A, k, p_idxs, *args, **kwargs):
         # recover dual variables for the remaining user-provided constraints
         if log_c_lin.size > 0:
             aff_duals = [0.] * log_c_lin.size
-            task.getsucslice(mosek.soltype.itr, 2*n_lse + p_lse, cur_con_idx,
+            task.getsucslice(mosek.soltype.itr, n_lse + p_lse, cur_con_idx,
                              aff_duals)
             aff_duals = np.array(aff_duals)
             aff_duals[aff_duals < 0] = 0

--- a/gpkit/build.py
+++ b/gpkit/build.py
@@ -122,6 +122,21 @@ class CVXopt(SolverBackend):
             pass
 
 
+class MosekConif(SolverBackend):
+
+    name = 'mosek_conif'
+
+    def look(self):
+        "Attempts to import mosek."
+        try:
+            log("#   Trying to import mosek...")
+            # Testing the import, so the variable is intentionally not used
+            import mosek  # pylint: disable=unused-variable
+            return "in Python path"
+        except ImportError:
+            pass
+
+
 class Mosek(SolverBackend):
     "MOSEK finder and builder."
     name = "mosek"
@@ -279,7 +294,7 @@ def build():
     log("Started building gpkit...\n")
 
     log("Attempting to find and build solvers:\n")
-    solvers = [Mosek(), MosekCLI(), CVXopt()]
+    solvers = [MosekConif(), Mosek(), MosekCLI(), CVXopt()]
     installed_solvers = [solver.name
                          for solver in solvers
                          if solver.installed]

--- a/gpkit/build.py
+++ b/gpkit/build.py
@@ -123,6 +123,7 @@ class CVXopt(SolverBackend):
 
 
 class MosekConif(SolverBackend):
+    "Find MOSEK version >= 9."
 
     name = 'mosek_conif'
 

--- a/gpkit/build.py
+++ b/gpkit/build.py
@@ -127,12 +127,15 @@ class MosekConif(SolverBackend):
     name = 'mosek_conif'
 
     def look(self):
-        "Attempts to import mosek."
+        "Attempts to import mosek, version >= 9."
         try:
             log("#   Trying to import mosek...")
             # Testing the import, so the variable is intentionally not used
             import mosek  # pylint: disable=unused-variable
-            return "in Python path"
+            if hasattr(mosek.conetype, 'pexp'):
+                return "in Python path"
+            else:
+                pass
         except ImportError:
             pass
 

--- a/gpkit/constraints/gp.py
+++ b/gpkit/constraints/gp.py
@@ -15,7 +15,7 @@ from ..exceptions import InvalidPosynomial
 
 
 DEFAULT_SOLVER_KWARGS = {"cvxopt": {"kktsolver": "ldl"}}
-SOLUTION_TOL = {"cvxopt": 1e-3, "mosek_cli": 1e-4, "mosek": 1e-5, 'mosek_conif': 1e-5}
+SOLUTION_TOL = {"cvxopt": 1e-3, "mosek_cli": 1e-4, "mosek": 1e-5, 'mosek_conif': 1e-3}
 
 
 def _get_solver(solver, kwargs):
@@ -38,7 +38,7 @@ def _get_solver(solver, kwargs):
     elif solver == "mosek":
         from .._mosek import expopt
         solverfn = expopt.imize
-    elif solver =='mosek_conif':
+    elif solver == 'mosek_conif':
         from .._mosek import mosek_conif
         solverfn = mosek_conif.mskoptimize
     elif hasattr(solver, "__call__"):

--- a/gpkit/constraints/gp.py
+++ b/gpkit/constraints/gp.py
@@ -93,7 +93,7 @@ class GeometricProgram(CostedConstraintSet, NomialData):
         self.posynomials.extend(self.as_posyslt1(self.substitutions))
         self.hmaps = [p.hmap for p in self.posynomials]
         ## Generate various maps into the posy- and monomials
-        # k [j]: number of monomials (columns of F) present in each constraint
+        # k [j]: number of monomials (rows of A) present in each constraint
         self.k = [len(hm) for hm in self.hmaps]
         p_idxs = []  # p_idxs [i]: posynomial index of each monomial
         self.m_idxs = []  # m_idxs [i]: monomial indices of each posynomial

--- a/gpkit/constraints/gp.py
+++ b/gpkit/constraints/gp.py
@@ -15,7 +15,8 @@ from ..exceptions import InvalidPosynomial
 
 
 DEFAULT_SOLVER_KWARGS = {"cvxopt": {"kktsolver": "ldl"}}
-SOLUTION_TOL = {"cvxopt": 1e-3, "mosek_cli": 1e-4, "mosek": 1e-5, 'mosek_conif': 1e-3}
+SOLUTION_TOL = {"cvxopt": 1e-3, "mosek_cli": 1e-4, "mosek": 1e-5,
+                'mosek_conif': 1e-3}
 
 
 def _get_solver(solver, kwargs):

--- a/gpkit/constraints/gp.py
+++ b/gpkit/constraints/gp.py
@@ -15,7 +15,7 @@ from ..exceptions import InvalidPosynomial
 
 
 DEFAULT_SOLVER_KWARGS = {"cvxopt": {"kktsolver": "ldl"}}
-SOLUTION_TOL = {"cvxopt": 1e-3, "mosek_cli": 1e-4, "mosek": 1e-5}
+SOLUTION_TOL = {"cvxopt": 1e-3, "mosek_cli": 1e-4, "mosek": 1e-5, 'mosek_conif': 1e-5}
 
 
 def _get_solver(solver, kwargs):
@@ -38,6 +38,9 @@ def _get_solver(solver, kwargs):
     elif solver == "mosek":
         from .._mosek import expopt
         solverfn = expopt.imize
+    elif solver =='mosek_conif':
+        from .._mosek import mosek_conif
+        solverfn = mosek_conif.mskoptimize
     elif hasattr(solver, "__call__"):
         solverfn = solver
         solver = solver.__name__

--- a/gpkit/tests/t_constraints.py
+++ b/gpkit/tests/t_constraints.py
@@ -62,7 +62,7 @@ class TestConstraint(unittest.TestCase):
         m = Model(x, [x == 3, x == 4])
         rc = ConstraintsRelaxed(m)
         m2 = Model(rc.relaxvars.prod() * x**0.01, rc)
-        self.assertAlmostEqual(m2.solve(verbosity=0)(x), 3, 5)
+        self.assertAlmostEqual(m2.solve(verbosity=0)(x), 3, places=3)
 
     def test_constraintget(self):
         x = Variable("x")

--- a/gpkit/tests/t_examples.py
+++ b/gpkit/tests/t_examples.py
@@ -113,7 +113,7 @@ class TestExamples(unittest.TestCase):
         with self.assertRaises(RuntimeWarning) as cm:
             example.m.solve(verbosity=0)
         err = str(cm.exception)
-        if "mosek" in err:
+        if "mosek" in err and 'mosek_conif' not in err:
             self.assertIn("PRIM_INFEAS_CER", err)
         elif "cvxopt" in err:
             self.assertIn("unknown", err)

--- a/gpkit/tests/t_examples.py
+++ b/gpkit/tests/t_examples.py
@@ -113,7 +113,9 @@ class TestExamples(unittest.TestCase):
         with self.assertRaises(RuntimeWarning) as cm:
             example.m.solve(verbosity=0)
         err = str(cm.exception)
-        if "mosek" in err and 'mosek_conif' not in err:
+        if 'mosek_conif' in err:
+            self.assertIn('infeasible', err)
+        elif "mosek" in err:
             self.assertIn("PRIM_INFEAS_CER", err)
         elif "cvxopt" in err:
             self.assertIn("unknown", err)

--- a/gpkit/tests/t_model.py
+++ b/gpkit/tests/t_model.py
@@ -319,7 +319,7 @@ class TestSP(unittest.TestCase):
         with SignomialsEnabled():
             m = Model(x, [x + y >= 1])  # dual infeasible
         with self.assertRaises((RuntimeWarning, ValueError)):
-            m.localsolve(verbosity=0, solver=self.solver),
+            m.localsolve(verbosity=0, solver=self.solver)
 
         with SignomialsEnabled():
             m = Model(x, Bounded([x + y >= 1], verbosity=0))

--- a/gpkit/tests/t_model.py
+++ b/gpkit/tests/t_model.py
@@ -29,7 +29,7 @@ class TestGP(unittest.TestCase):
     name = "TestGP_"
     # solver and ndig get set in loop at bottom this file, a bit hacky
     solver = None
-    ndig = None
+    ndig = 4
 
     def test_trivial_gp(self):
         """
@@ -64,7 +64,7 @@ class TestGP(unittest.TestCase):
                           SignomialEquality(x**2 + x, y)])
         sol = m.localsolve(solver=self.solver, verbosity=0, mutategp=False)
         self.assertAlmostEqual(sol("x"), 0.1639472, self.ndig)
-        self.assertAlmostEqual(sol("y")[0], 0.1908254, self.ndig)
+        self.assertAlmostEqual(sol("y")[0], 0.1908254, 3)
         self.assertAlmostEqual(sol("c"), 0.2669448, self.ndig)
         # test right vector input to sigeq
         with SignomialsEnabled():
@@ -80,9 +80,9 @@ class TestGP(unittest.TestCase):
             m = Model(c, [c >= (x + 0.25)**2 + (y - 0.5)**2,
                           SignomialEquality(x**2 + x, y)])
         sol = m.localsolve(solver=self.solver, verbosity=0)
-        self.assertAlmostEqual(sol("x"), 0.1639472, self.ndig)
-        self.assertAlmostEqual(sol("y"), 0.1908254, self.ndig)
-        self.assertAlmostEqual(sol("c"), 0.2669448, self.ndig)
+        self.assertAlmostEqual(sol("x"), 0.1639472, 3)
+        self.assertAlmostEqual(sol("y"), 0.1908254, 3)
+        self.assertAlmostEqual(sol("c"), 0.2669448, 3)
 
     def test_601(self):
         # tautological monomials should solve but not pass to the solver
@@ -271,7 +271,7 @@ class TestSP(unittest.TestCase):
     """test case for SP class -- gets run for each installed solver"""
     name = "TestSP_"
     solver = None
-    ndig = None
+    ndig = 4
 
     def test_sp_relaxation(self):
         w = Variable('w')
@@ -626,7 +626,7 @@ class TestSP(unittest.TestCase):
         x = Variable("x")
         y = Variable("y")
         m = Model(x*y, [x*y**1.01 >= 100])
-        with self.assertRaises(InvalidPosynomial):
+        with self.assertRaises((RuntimeWarning, InvalidPosynomial)):
             m.solve(self.solver, verbosity=0)
         # test one-sided bound
         m = Model(x*y, Bounded(m, verbosity=0, lower=0.001))
@@ -650,6 +650,7 @@ class TestSP(unittest.TestCase):
         self.assertEqual(len(m.program.gps[-1].varkeys), 3)
         self.assertAlmostEqual(sol['cost'], sol_pccp['cost'])
 
+
 class TestModelSolverSpecific(unittest.TestCase):
     """test cases run only for specific solvers"""
     def test_cvxopt_kwargs(self):
@@ -670,10 +671,12 @@ class Thing(Model):
         c = Variable("c", 17/4., "g")
         return [a >= c/b]
 
+
 class Thing2(Model):
     "another thing for model testing"
     def setup(self):
         return [Thing(2), Model()]
+
 
 class SPThing(Model):
     "a simple SP"
@@ -685,6 +688,7 @@ class SPThing(Model):
             constraints = [z <= x**2 + y, x*z == 2]
         self.cost = 1/z
         return constraints
+
 
 class Box(Model):
     """simple box for model testing
@@ -778,6 +782,7 @@ class TestModelNoSolve(unittest.TestCase):
         # dig a level deeper, into the keymap
         self.assertEqual(len(w.varkeys.keymap["m"]), 2)
         w2 = Widget()
+
 
 TESTS = [TestModelSolverSpecific, TestModelNoSolve]
 MULTI_SOLVER_TESTS = [TestGP, TestSP]

--- a/gpkit/tests/t_model.py
+++ b/gpkit/tests/t_model.py
@@ -626,7 +626,7 @@ class TestSP(unittest.TestCase):
         x = Variable("x")
         y = Variable("y")
         m = Model(x*y, [x*y**1.01 >= 100])
-        with self.assertRaises((RuntimeWarning, InvalidPosynomial)):
+        with self.assertRaises((RuntimeWarning, ValueError, InvalidPosynomial)):
             m.solve(self.solver, verbosity=0)
         # test one-sided bound
         m = Model(x*y, Bounded(m, verbosity=0, lower=0.001))

--- a/gpkit/tests/t_model.py
+++ b/gpkit/tests/t_model.py
@@ -64,7 +64,7 @@ class TestGP(unittest.TestCase):
                           SignomialEquality(x**2 + x, y)])
         sol = m.localsolve(solver=self.solver, verbosity=0, mutategp=False)
         self.assertAlmostEqual(sol("x"), 0.1639472, self.ndig)
-        self.assertAlmostEqual(sol("y")[0], 0.1908254, 3)
+        self.assertAlmostEqual(sol("y")[0], 0.1908254, self.ndig)
         self.assertAlmostEqual(sol("c"), 0.2669448, self.ndig)
         # test right vector input to sigeq
         with SignomialsEnabled():
@@ -80,9 +80,9 @@ class TestGP(unittest.TestCase):
             m = Model(c, [c >= (x + 0.25)**2 + (y - 0.5)**2,
                           SignomialEquality(x**2 + x, y)])
         sol = m.localsolve(solver=self.solver, verbosity=0)
-        self.assertAlmostEqual(sol("x"), 0.1639472, 3)
-        self.assertAlmostEqual(sol("y"), 0.1908254, 3)
-        self.assertAlmostEqual(sol("c"), 0.2669448, 3)
+        self.assertAlmostEqual(sol("x"), 0.1639472, self.ndig)
+        self.assertAlmostEqual(sol("y"), 0.1908254, self.ndig)
+        self.assertAlmostEqual(sol("c"), 0.2669448, self.ndig)
 
     def test_601(self):
         # tautological monomials should solve but not pass to the solver

--- a/gpkit/tests/t_solution_array.py
+++ b/gpkit/tests/t_solution_array.py
@@ -15,7 +15,7 @@ class TestSolutionArray(unittest.TestCase):
         A = Variable('A', '-', 'Test Variable')
         prob = Model(A, [A >= 1])
         sol = prob.solve(verbosity=0)
-        self.assertAlmostEqual(sol(A), 1.0, 10)
+        self.assertAlmostEqual(sol(A), 1.0, 8)
 
     def test_call_units(self):
         # test from issue541
@@ -35,7 +35,8 @@ class TestSolutionArray(unittest.TestCase):
         self.assertEqual(type(solx), Quantity)
         self.assertEqual(type(sol["variables"][x]), np.ndarray)
         self.assertEqual(solx.shape, (n,))
-        self.assertTrue((abs(solx - 2.5*np.ones(n)) < 1e-7).all())
+        for i in range(n):
+            self.assertAlmostEqual(solx[i], 2.5, places=4)
 
     def test_subinto(self):
         Nsweep = 20
@@ -72,7 +73,7 @@ class TestSolutionArray(unittest.TestCase):
         tminsub = 1000 * gpkit.ureg.lbf
         m.substitutions.update({Tmin: tminsub})
         sol = m.solve(verbosity=0)
-        self.assertEqual(sol(Tmin), tminsub)
+        self.assertEqual(sol(Tmin) - tminsub, 0)
         self.assertFalse(
             "1000N" in
             sol.table().replace(" ", "").replace("[", "").replace("]", ""))


### PR DESCRIPTION
Following my comments on #1396, here is a PR for proper MOSEK 9 support. The implementation accomplishes the same thing as #1374 , except it uses the "Optimizer" interface instead of the "Fusion" interface. The Optimizer interface is considered more stable, and is faster than the Fusion interface.

All solver related tests are passing. If you run the full suite of tests, you'll find that five are failing due to ``pint`` complaining about unit conversions, and three are failing due to string-rendering / pretty-printing of signomials.

Here is natural follow-up work, if this PR is to be merged:
 * Allow handling for more user-provided MOSEK parameters. To do this well, refer to [CVXPY's MOSEK interface](https://github.com/cvxgrp/cvxpy/blob/master/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py), specifically lines 228-241 and 571-602.
 * Allow mixed-integer geometric programming. This is doable, but it will require an unusual formulation. Once you've settled on a formulation, updating this mosek interface shouldn't be that hard. If need be, I can help with that when the time comes.
 * Fix non-solver-related tests that are currently failing.
 * Drop the other mosek interfaces. The code duplication is pretty bad right now. Also, if you drop ``mosek_cli`` and the C-based ``mosek`` interface, installing GPKit will become *much* easier. You wouldn't need a "build" phase at all!
