### PR TITLE
Fixing .debug issues with VectorVars. 

### DIFF
--- a/gpkit/nomials/substitution.py
+++ b/gpkit/nomials/substitution.py
@@ -4,7 +4,7 @@ from ..small_scripts import splitsweep
 
 
 def parse_subs(varkeys, substitutions, clean=False):
-    "Seperates subs into the constants, sweeps, linkedsweeps actually present."
+    "Separates subs into the constants, sweeps, linkedsweeps actually present."
     constants, sweep, linkedsweep = {}, {}, {}
     if clean:
         for var in varkeys:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """Standard Python setup script for gpkit"""
 import os
-from distutils.core import setup
+from setuptools import setup
 
 LONG_DESCRIPTION = """
 GPkit is a Python package for defining and manipulating


### PR DESCRIPTION
Issues have to do with ```constants``` having different varkeys than ```substitutions```. Now, just create a new subs dict to avoid issues using del. 