### PR TITLE
Partial vector substitution

### DIFF
--- a/gpkit/keydict.py
+++ b/gpkit/keydict.py
@@ -4,6 +4,7 @@ from collections.abc import Hashable
 import numpy as np
 from .small_classes import Numbers, Quantity, FixedScalar
 from .small_scripts import is_sweepvar, isnan
+from .varkey import GLOBAL_KEYMAP
 
 DIMLESS_QUANTITY = Quantity(1, "dimensionless")
 INT_DTYPE = np.dtype(int)
@@ -46,6 +47,7 @@ class KeyMap:
     keymap = []
     log_gets = False
     varkeys = None
+    vks = None
 
     def __init__(self, *args, **kwargs):
         "Passes through to super().__init__ via the `update()` method"
@@ -62,9 +64,11 @@ class KeyMap:
                 return key.veckey, key.idx
             return key, None
         except AttributeError:
-            if not self.varkeys:
+            if not self.vks:
                 return key, self.update_keymap()
         # looks like we're in a substitutions dictionary
+        if not self.varkeys:
+            self.varkeys = KeySet(self.vks)
         if key not in self.varkeys:  # pylint:disable=unsupported-membership-test
             raise KeyError(key)
         newkey, *otherkeys = self.varkeys[key]  # pylint:disable=unsubscriptable-object
@@ -195,6 +199,8 @@ class KeyDict(KeyMap, dict):
                 raise e
             if not hasattr(value, "shape"):
                 value = np.full(key.shape, value)
+            elif key.shape != value.shape:
+                raise KeyError("Key and value have different shapes") from e
             for subkey, subval in zip(key.flat, value.flat):
                 self[subkey] = subval
             return

--- a/gpkit/keydict.py
+++ b/gpkit/keydict.py
@@ -187,7 +187,19 @@ class KeyDict(KeyMap, dict):
     def __setitem__(self, key, value):
         "Overloads __setitem__ and []= to work with all keys"
         # pylint: disable=too-many-boolean-expressions
-        key, idx = self.parse_and_index(key)
+        try:
+            key, idx = self.parse_and_index(key)
+        except KeyError as e:  # may be indexed VectorVariable
+            # NOTE: this check takes ~4% of the time in this loop
+            #        and arguably the functionality isn't worth it
+            if hasattr(key, "shape"):
+                if not hasattr(value, "shape"):
+                    value = np.full(key.shape, value)
+                for subkey, subval in zip(key.flat, value.flat):
+                    if not hasattr(subkey, "key"):
+                        raise e
+                    self[subkey] = subval
+            return
         value = clean_value(key, value)
         if key not in self.keymap:
             if not hasattr(self, "_unmapped_keys"):

--- a/gpkit/keydict.py
+++ b/gpkit/keydict.py
@@ -4,7 +4,6 @@ from collections.abc import Hashable
 import numpy as np
 from .small_classes import Numbers, Quantity, FixedScalar
 from .small_scripts import is_sweepvar, isnan
-from .varkey import GLOBAL_KEYMAP
 
 DIMLESS_QUANTITY = Quantity(1, "dimensionless")
 INT_DTYPE = np.dtype(int)
@@ -47,7 +46,6 @@ class KeyMap:
     keymap = []
     log_gets = False
     varkeys = None
-    vks = None
 
     def __init__(self, *args, **kwargs):
         "Passes through to super().__init__ via the `update()` method"
@@ -64,11 +62,9 @@ class KeyMap:
                 return key.veckey, key.idx
             return key, None
         except AttributeError:
-            if not self.vks:
+            if not self.varkeys:
                 return key, self.update_keymap()
         # looks like we're in a substitutions dictionary
-        if not self.varkeys:
-            self.varkeys = KeySet(self.vks)
         if key not in self.varkeys:  # pylint:disable=unsupported-membership-test
             raise KeyError(key)
         newkey, *otherkeys = self.varkeys[key]  # pylint:disable=unsubscriptable-object

--- a/gpkit/keydict.py
+++ b/gpkit/keydict.py
@@ -186,19 +186,17 @@ class KeyDict(KeyMap, dict):
 
     def __setitem__(self, key, value):
         "Overloads __setitem__ and []= to work with all keys"
-        # pylint: disable=too-many-boolean-expressions
+        # pylint: disable=too-many-boolean-expressions,too-many-branches
         try:
             key, idx = self.parse_and_index(key)
         except KeyError as e:  # may be indexed VectorVariable
-            # NOTE: this check takes ~4% of the time in this loop
-            #        and arguably the functionality isn't worth it
-            if hasattr(key, "shape"):
-                if not hasattr(value, "shape"):
-                    value = np.full(key.shape, value)
-                for subkey, subval in zip(key.flat, value.flat):
-                    if not hasattr(subkey, "key"):
-                        raise e
-                    self[subkey] = subval
+            # NOTE: this try/except takes ~4% of the time in this loop
+            if not hasattr(key, "shape"):
+                raise e
+            if not hasattr(value, "shape"):
+                value = np.full(key.shape, value)
+            for subkey, subval in zip(key.flat, value.flat):
+                self[subkey] = subval
             return
         value = clean_value(key, value)
         if key not in self.keymap:


### PR DESCRIPTION
allows substitutions like ```m.substitutions[v[0,2:]] = 1  # or np.ones(v[0,2:].shape)```